### PR TITLE
test OpenShift orchestrator in engine test

### DIFF
--- a/pkg/acsengine/testdata/simple/openshift.json
+++ b/pkg/acsengine/testdata/simple/openshift.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "OpenShift",
+      "openShiftConfig": {
+        "adminUsername": "",
+        "adminPassword": "",
+        "sshKeyData": "",
+        "WildcardZone": "",
+        "rhnUsername": "",
+        "rhnPassword": "",
+        "SubscriptionPoolId": "",
+        "sshPrivateData": "",
+        "aadClientId": "",
+        "aadClientSecret": ""
+      }
+    },
+    "masterProfile": {
+      "count": 1,
+      "dnsPrefix": "masterdns1",
+      "vmSize": "Standard_D2_v2"
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "agentpool1",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      },
+      {
+        "name": "agentpool2",
+        "count": 3,
+        "vmSize": "Standard_D2_v2",
+        "availabilityProfile": "AvailabilitySet"
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": "ssh-rsa PUBLICKEY azureuser@linuxvm"
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "ServicePrincipalClientID",
+      "secret": "myServicePrincipalClientSecret"
+    }
+  }
+}


### PR DESCRIPTION
Requires https://github.com/kargakis/acs-engine/pull/3

Adding this test file ensures the openshift orchestrator type is tested in https://github.com/pweil-/acs-engine/blob/8cd9bad59ff853f861b95d6e3e38c2e573db6842/pkg/acsengine/engine_test.go#L37-L37

@jim-minter @kargakis