### PR TITLE
Approve CSRs for bootstrapping the cluster

### DIFF
--- a/parts/openshift/master.sh
+++ b/parts/openshift/master.sh
@@ -231,6 +231,34 @@ done
 mkdir -p /root/.kube
 cp /etc/origin/master/admin.kubeconfig /root/.kube/config
 
+# TODO: run a CSR auto-approver
+# https://github.com/kargakis/acs-engine/issues/46
+csrs=($(oc get csr -o name))
+while [[ ${#csrs[@]} != "3" ]]; do
+	sleep 2
+	csrs=($(oc get csr -o name))
+	if [[ ${#csrs[@]} == "3" ]]; then
+		break
+	fi
+done
+
+for csr in ${csrs[@]}; do
+	oc adm certificate approve $csr
+done
+
+csrs=($(oc get csr -o name))
+while [[ ${#csrs[@]} != "6" ]]; do
+	sleep 2
+	csrs=($(oc get csr -o name))
+	if [[ ${#csrs[@]} == "6" ]]; then
+		break
+	fi
+done
+
+for csr in ${csrs[@]}; do
+	oc adm certificate approve $csr
+done
+
 # TODO: possibly wait here for convergence?
 
 exit 0


### PR DESCRIPTION
Assuming we get CSRs correctly, this should approve all of them. Opened https://github.com/kargakis/acs-engine/issues/46 for tracking using the CSR auto-approver.