### PR TITLE
Reduce templatization

### DIFF
--- a/parts/openshift/openshift.json
+++ b/parts/openshift/openshift.json
@@ -537,7 +537,7 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {},
                 "protectedSettings": {
-                    "script": "{{ Base64 (OpenShiftGetNodeSh "infra1") }}"
+                    "script": "{{ Base64 (OpenShiftGetNodeSh true) }}"
                 }
             }
         },
@@ -556,7 +556,7 @@
                 "autoUpgradeMinorVersion": true,
                 "settings": {},
                 "protectedSettings": {
-                    "script": "{{ Base64 (OpenShiftGetNodeSh "node1") }}"
+                    "script": "{{ Base64 (OpenShiftGetNodeSh false) }}"
                 }
             }
         }

--- a/pkg/acsengine/engine.go
+++ b/pkg/acsengine/engine.go
@@ -1649,7 +1649,7 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 			})
 			return b.String()
 		},
-		"OpenShiftGetNodeSh": func(node string) string {
+		"OpenShiftGetNodeSh": func(isInfra bool) string {
 			tb := MustAsset("openshift/node.sh")
 			t := template.Must(template.New("node").Parse(string(tb)))
 			b := &bytes.Buffer{}
@@ -1657,8 +1657,8 @@ func (t *TemplateGenerator) getTemplateFuncMap(cs *api.ContainerService) templat
 				ConfigBundle string
 				IsInfra      bool
 			}{
-				ConfigBundle: base64.StdEncoding.EncodeToString(cs.Properties.OrchestratorProfile.OpenShiftConfig.ConfigBundles[node]),
-				IsInfra:      cs.Properties.OrchestratorProfile.OpenShiftConfig.InfraNodes[node],
+				ConfigBundle: base64.StdEncoding.EncodeToString(cs.Properties.OrchestratorProfile.OpenShiftConfig.ConfigBundles["bootstrap"]),
+				IsInfra:      isInfra,
 			})
 			return b.String()
 		},

--- a/pkg/certgen/files.go
+++ b/pkg/certgen/files.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PrepareMasterFiles creates the shared authentication and encryption secrets
-func (c *Config) PrepareMasterFiles(node *Node) error {
+func (c *Config) PrepareMasterFiles() error {
 	b := make([]byte, 24)
 	_, err := rand.Read(b)
 	if err != nil {
@@ -31,7 +31,7 @@ func (c *Config) PrepareMasterFiles(node *Node) error {
 }
 
 // WriteMasterFiles writes the templated master config
-func (c *Config) WriteMasterFiles(fs filesystem.Filesystem, node *Node) error {
+func (c *Config) WriteMasterFiles(fs filesystem.Filesystem) error {
 	for _, name := range templates.AssetNames() {
 		if !strings.HasPrefix(name, "master/") {
 			continue
@@ -61,11 +61,12 @@ func (c *Config) WriteMasterFiles(fs filesystem.Filesystem, node *Node) error {
 }
 
 // WriteNodeFiles writes the templated node config
-func (c *Config) WriteNodeFiles(fs filesystem.Filesystem, node *Node) error {
+func (c *Config) WriteNodeFiles(fs filesystem.Filesystem) error {
 	for _, name := range templates.AssetNames() {
 		if !strings.HasPrefix(name, "node/") {
 			continue
 		}
+
 		tb := templates.MustAsset(name)
 
 		t, err := template.New("template").Funcs(template.FuncMap{
@@ -76,7 +77,7 @@ func (c *Config) WriteNodeFiles(fs filesystem.Filesystem, node *Node) error {
 		}
 
 		b := &bytes.Buffer{}
-		err = t.Execute(b, node)
+		err = t.Execute(b, struct{}{})
 		if err != nil {
 			return err
 		}

--- a/pkg/certgen/templates/master/etc/etcd/etcd.conf
+++ b/pkg/certgen/templates/master/etc/etcd/etcd.conf
@@ -1,26 +1,26 @@
-ETCD_NAME={{ (index .Nodes 0).Hostname }}
-ETCD_LISTEN_PEER_URLS=https://{{ (index (index .Nodes 0).IPs 0).String }}:2380
+ETCD_NAME={{ .Master.Hostname }}
+ETCD_LISTEN_PEER_URLS=https://{{ (index .Master.IPs 0).String }}:2380
 ETCD_DATA_DIR=/var/lib/etcd/
 #ETCD_WAL_DIR=""
 #ETCD_SNAPSHOT_COUNT=10000
 ETCD_HEARTBEAT_INTERVAL=500
 ETCD_ELECTION_TIMEOUT=2500
-ETCD_LISTEN_CLIENT_URLS=https://{{ (index (index .Nodes 0).IPs 0).String }}:2379
+ETCD_LISTEN_CLIENT_URLS=https://{{ (index .Master.IPs 0).String }}:2379
 #ETCD_MAX_SNAPSHOTS=5
 #ETCD_MAX_WALS=5
 #ETCD_CORS=
 
 
 #[cluster]
-ETCD_INITIAL_ADVERTISE_PEER_URLS=https://{{ (index (index .Nodes 0).IPs 0).String }}:2380
-ETCD_INITIAL_CLUSTER={{ (index .Nodes 0).Hostname }}=https://{{ (index (index .Nodes 0).IPs 0).String }}:2380
+ETCD_INITIAL_ADVERTISE_PEER_URLS=https://{{ (index .Master.IPs 0).String }}:2380
+ETCD_INITIAL_CLUSTER={{ .Master.Hostname }}=https://{{ (index .Master.IPs 0).String }}:2380
 ETCD_INITIAL_CLUSTER_STATE=new
 ETCD_INITIAL_CLUSTER_TOKEN=etcd-cluster-1
 #ETCD_DISCOVERY=
 #ETCD_DISCOVERY_SRV=
 #ETCD_DISCOVERY_FALLBACK=proxy
 #ETCD_DISCOVERY_PROXY=
-ETCD_ADVERTISE_CLIENT_URLS=https://{{ (index (index .Nodes 0).IPs 0).String }}:2379
+ETCD_ADVERTISE_CLIENT_URLS=https://{{ (index .Master.IPs 0).String }}:2379
 #ETCD_STRICT_RECONFIG_CHECK="false"
 #ETCD_AUTO_COMPACTION_RETENTION="0"
 #ETCD_ENABLE_V2="true"

--- a/pkg/certgen/templates/master/etc/origin/master/master-config.yaml
+++ b/pkg/certgen/templates/master/etc/origin/master/master-config.yaml
@@ -60,13 +60,13 @@ controllers: '*'
 corsAllowedOrigins:
 - (?i)//127\.0\.0\.1(:|\z)
 - (?i)//localhost(:|\z)
-- (?i)//{{ QuoteMeta (index (index .Nodes 0).IPs 0).String }}(:|\z)
+- (?i)//{{ QuoteMeta (index .Master.IPs 0).String }}(:|\z)
 - (?i)//kubernetes\.default(:|\z)
 - (?i)//kubernetes\.default\.svc\.cluster\.local(:|\z)
 - (?i)//kubernetes(:|\z)
 - (?i)//{{ QuoteMeta .ExternalMasterHostname }}(:|\z)
 - (?i)//openshift\.default(:|\z)
-- (?i)//{{ QuoteMeta (index .Nodes 0).Hostname }}(:|\z)
+- (?i)//{{ QuoteMeta .Master.Hostname }}(:|\z)
 - (?i)//openshift\.default\.svc(:|\z)
 - (?i)//kubernetes\.default\.svc(:|\z)
 - (?i)//172\.30\.0\.1(:|\z)
@@ -80,7 +80,7 @@ etcdClientInfo:
   certFile: master.etcd-client.crt
   keyFile: master.etcd-client.key
   urls:
-  - https://{{ (index .Nodes 0).Hostname }}:2379
+  - https://{{ .Master.Hostname }}:2379
 etcdStorageConfig:
   kubernetesStoragePrefix: kubernetes.io
   kubernetesStorageVersion: v1
@@ -109,7 +109,7 @@ kubernetesMasterConfig:
     cluster-signing-key-file:
       - "/etc/origin/master/ca.key"
   masterCount: 1
-  masterIP: {{ (index (index .Nodes 0).IPs 0).String }}
+  masterIP: {{ (index .Master.IPs 0).String }}
   podEvictionTimeout: null
   proxyClientInfo:
     certFile: master.proxy-client.crt
@@ -132,7 +132,7 @@ masterClients:
     contentType: application/vnd.kubernetes.protobuf
     qps: 300
   openshiftLoopbackKubeConfig: openshift-master.kubeconfig
-masterPublicURL: https://{{ .ExternalMasterHostname }}:{{ (index .Nodes 0).Master.Port }}
+masterPublicURL: https://{{ .ExternalMasterHostname }}:{{ .Master.Port }}
 networkConfig:
   clusterNetworkCIDR: 10.128.0.0/14
   clusterNetworks:
@@ -144,7 +144,7 @@ networkConfig:
   networkPluginName: redhat/openshift-ovs-subnet
   serviceNetworkCIDR: 172.30.0.0/16
 oauthConfig:
-  assetPublicURL: https://{{ .ExternalMasterHostname }}:{{ (index .Nodes 0).Master.Port }}/console/
+  assetPublicURL: https://{{ .ExternalMasterHostname }}:{{ .Master.Port }}/console/
   grantConfig:
     method: auto
   identityProviders:
@@ -157,8 +157,8 @@ oauthConfig:
       file: /etc/origin/master/htpasswd
       kind: HTPasswdPasswordIdentityProvider
   masterCA: ca-bundle.crt
-  masterPublicURL: https://{{ .ExternalMasterHostname }}:{{ (index .Nodes 0).Master.Port }}
-  masterURL: https://{{ .ExternalMasterHostname }}:{{ (index .Nodes 0).Master.Port }}
+  masterPublicURL: https://{{ .ExternalMasterHostname }}:{{ .Master.Port }}
+  masterURL: https://{{ .ExternalMasterHostname }}:{{ .Master.Port }}
   sessionConfig:
     sessionMaxAgeSeconds: 3600
     sessionName: ssn
@@ -192,7 +192,7 @@ serviceAccountConfig:
   publicKeyFiles:
   - serviceaccounts.public.key
 servingInfo:
-  bindAddress: 0.0.0.0:{{ (index .Nodes 0).Master.Port }}
+  bindAddress: 0.0.0.0:{{ .Master.Port }}
   bindNetwork: tcp4
   certFile: master.server.crt
   clientCA: ca.crt


### PR DESCRIPTION
@jim-minter honestly I don't feel strong about this code but it gets us a step closer to what we want it to be (config for master and bootstrap config for every node). I've tested it and it works fine.

/assign @jim-minter 

@glennswest this should fix the issue I mentioned in aos-azure regarding generating the correct node name inside the golang template. Unfortunately, I think we need to table https://github.com/kargakis/acs-engine/issues/25 and instead move to reuse the kubernetes templates in https://github.com/kargakis/acs-engine/tree/master/parts/k8s as per discussions with Azure folks from today;s meeting (I am working on it).

cc @pweil- 