### PR TITLE
re-use openshift-ansible playbooks for router deploy

### DIFF
--- a/parts/k8s/openshiftmasterscript.sh
+++ b/parts/k8s/openshiftmasterscript.sh
@@ -44,6 +44,7 @@ update-ca-trust
 routerLBHost="{{.RouterLBHostname}}"
 routerLBIP=$(dig +short $routerLBHost)
 sed -i "s/TEMPROUTERIP/${routerLBIP}/" /etc/origin/master/master-config.yaml
+sed -i "s/TEMPROUTERIP/${routerLBIP}/" /tmp/ansible-playbooks/azure-local-master-inventory.yml
 
 # TODO: when enabling secure registry, may need:
 # ln -s /etc/origin/node/node-client-ca.crt /etc/docker/certs.d/docker-registry.default.svc:5000
@@ -123,8 +124,8 @@ oc patch project default -p '{"metadata":{"annotations":{"openshift.io/node-sele
 
 oc adm registry --images='registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}' --selector='region=infra'
 
-oc adm policy add-scc-to-user hostnetwork -z router
-oc adm router --images='registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}' --selector='region=infra'
+# Deploy the router reusing relevant parts from openshift-ansible
+ANSIBLE_ROLES_PATH=/usr/share/ansible/openshift-ansible/roles/ ansible-playbook -c local /tmp/ansible-playbooks/deploy-router.yml -i /tmp/ansible-playbooks/azure-local-master-inventory.yml
 
 oc create -f - <<'EOF'
 kind: Project

--- a/pkg/certgen/templates/master/tmp/ansible-playbooks/azure-local-master-inventory.yml
+++ b/pkg/certgen/templates/master/tmp/ansible-playbooks/azure-local-master-inventory.yml
@@ -1,0 +1,27 @@
+---
+localmaster:
+  hosts:
+    localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: /usr/bin/python2
+
+    oreg_url_master: 'registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}'
+
+    # The value of TEMPROUTERIP will be substituted during the acs-engine ARM
+    # Deployment process with the correct ip address
+    openshift_master_default_subdomain: 'TEMPROUTERIP.nip.io'
+
+    # FIXME
+    # This should be type=infra, but we have to live with region=infra for now
+    # because of legacy reasons
+    openshift_router_selector: 'region=infra'
+    openshift_deployment_type: 'openshift-enterprise'
+    # NOTE: Do not define openshift_hosted_router_replicas so that the task file
+    # router.yml inside the openshift_hosted role from openshift-ansible will
+    # autopopulate it using the openshift_hosted_router_selector and querying
+    # the number of infra nodes
+
+    openshift:
+      common:
+        config_base: /etc/origin/

--- a/pkg/certgen/templates/master/tmp/ansible-playbooks/deploy-router.yml
+++ b/pkg/certgen/templates/master/tmp/ansible-playbooks/deploy-router.yml
@@ -1,0 +1,9 @@
+- name: Deploy the local OpenShift Router
+  hosts: localmaster
+  gather_facts: false
+
+  tasks:
+    - name: Import and use router task file from openshift-ansible openshift_hosted role
+      import_role:
+        name: openshift_hosted
+        tasks_from: router.yml

--- a/pkg/certgen/tls.go
+++ b/pkg/certgen/tls.go
@@ -462,7 +462,7 @@ func (c *Config) WriteMasterCerts(fs filesystem.Filesystem) error {
 		}
 	}
 
-	return nil
+	return fs.WriteFile("etc/origin/master/ca.serial.txt", []byte(fmt.Sprintf("%02X\n", c.serial.Get())), 0666)
 }
 
 // WriteBootstrapCerts writes the node bootstrap certs


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Re-uses the ansible role task file for deploying a router that is used by openshift-ansible, this allows us to be consistent with the deployment practices of openshift-ansible but without having to pull in their entire deployment strategy.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Re-use openshift-ansible router deployment for consistency with upstream deployment methods
```
