### PR TITLE
use appropriate container images depending on origin/ose installs

### DIFF
--- a/pkg/certgen/templates/master/etc/origin/master/master-config.yaml
+++ b/pkg/certgen/templates/master/etc/origin/master/master-config.yaml
@@ -87,7 +87,7 @@ etcdStorageConfig:
   openShiftStoragePrefix: openshift.io
   openShiftStorageVersion: v1
 imageConfig:
-  format: registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}
+  format: TEMPIMAGEBASE-${component}:${version}
   latest: false
 kind: MasterConfig
 kubeletClientInfo:

--- a/pkg/certgen/templates/master/tmp/ansible-playbooks/azure-local-master-inventory.yml
+++ b/pkg/certgen/templates/master/tmp/ansible-playbooks/azure-local-master-inventory.yml
@@ -6,7 +6,7 @@ localmaster:
     ansible_connection: local
     ansible_python_interpreter: /usr/bin/python2
 
-    oreg_url_master: 'registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}'
+    oreg_url_master: 'TEMPIMAGEBASE-${component}:${version}'
 
     # The value of TEMPROUTERIP will be substituted during the acs-engine ARM
     # Deployment process with the correct ip address

--- a/pkg/certgen/templates/master/tmp/bootstrapconfigs/compute-config.yaml
+++ b/pkg/certgen/templates/master/tmp/bootstrapconfigs/compute-config.yaml
@@ -8,7 +8,7 @@ dockerConfig:
   execHandlerName: ""
 iptablesSyncPeriod: "30s"
 imageConfig:
-  format: registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}
+  format: TEMPIMAGEBASE-${component}:${version}
   latest: False
 kind: NodeConfig
 kubeletArguments:

--- a/pkg/certgen/templates/master/tmp/bootstrapconfigs/infra-config.yaml
+++ b/pkg/certgen/templates/master/tmp/bootstrapconfigs/infra-config.yaml
@@ -8,7 +8,7 @@ dockerConfig:
   execHandlerName: ""
 iptablesSyncPeriod: "30s"
 imageConfig:
-  format: registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}
+  format: TEMPIMAGEBASE-${component}:${version}
   latest: False
 kind: NodeConfig
 kubeletArguments:

--- a/pkg/certgen/templates/master/tmp/bootstrapconfigs/master-config.yaml
+++ b/pkg/certgen/templates/master/tmp/bootstrapconfigs/master-config.yaml
@@ -8,7 +8,7 @@ dockerConfig:
   execHandlerName: ""
 iptablesSyncPeriod: "30s"
 imageConfig:
-  format: registry.reg-aws.openshift.com:443/openshift3/ose-${component}:${version}
+  format: TEMPIMAGEBASE-${component}:${version}
   latest: False
 kind: NodeConfig
 kubeletArguments:

--- a/pkg/certgen/templates/master/tmp/service-catalog/objects.yaml
+++ b/pkg/certgen/templates/master/tmp/service-catalog/objects.yaml
@@ -49,7 +49,7 @@ objects:
           - KubernetesNamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck
           - --feature-gates
           - OriginatingIdentity=true
-          image: registry.reg-aws.openshift.com:443/openshift3/ose-service-catalog:v3.9.11
+          image: ${IMAGE}
           command: ["/usr/bin/service-catalog"]
           imagePullPolicy: IfNotPresent
           name: apiserver
@@ -154,7 +154,7 @@ objects:
           - "5m"
           - --feature-gates
           - OriginatingIdentity=true
-          image: registry.reg-aws.openshift.com:443/openshift3/ose-service-catalog:v3.9.11
+          image: ${IMAGE}
           command: ["/usr/bin/service-catalog"]
           imagePullPolicy: IfNotPresent
           name: controller-manager
@@ -184,3 +184,4 @@ parameters:
 - name: ETCD_SERVER
 - name: NAMESPACE
   value: kube-service-catalog
+- name: IMAGE


### PR DESCRIPTION
@kwoodson fyi

I was hoping to get rid of "registry.reg-aws.openshift.com" this time around, but it'll need a new image (built on v3.9.14-1_2018-03-22.2).  Next week...